### PR TITLE
Fix fantasy and stories sidebar links

### DIFF
--- a/resources/views/components/layouts/app.blade.php
+++ b/resources/views/components/layouts/app.blade.php
@@ -74,12 +74,12 @@
                     </a>
                   </li>
                   <li>
-                    <a href="#"
+                    <a href="{{ route('app.fantasies.index') }}"
                        wire:navigate
                        @class([
                          'group flex gap-x-3 rounded-md p-3 text-base font-semibold leading-relaxed',
-                         'bg-red-600 dark:bg-red-800/20 text-white' => false, // No route yet
-                         'text-red-200 dark:text-red-200/80 hover:text-white hover:bg-red-600 dark:hover:bg-red-700/25' => true
+                         'bg-red-600 dark:bg-red-800/20 text-white' => request()->routeIs('app.fantasies.*'),
+                         'text-red-200 dark:text-red-200/80 hover:text-white hover:bg-red-600 dark:hover:bg-red-700/25' => !request()->routeIs('app.fantasies.*')
                        ])>
                       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" data-slot="icon" aria-hidden="true" class="size-6 shrink-0 text-white">
                         <path d="M21 8.25c0-2.485-2.099-4.5-4.688-4.5-1.935 0-3.597 1.126-4.312 2.733-.715-1.607-2.377-2.733-4.313-2.733C5.1 3.75 3 5.765 3 8.25c0 7.22 9 12 9 12s9-4.78 9-12z" stroke-linecap="round" stroke-linejoin="round" />
@@ -88,12 +88,12 @@
                     </a>
                   </li>
                   <li>
-                    <a href="#"
+                    <a href="{{ route('app.stories.index') }}"
                        wire:navigate
                        @class([
                          'group flex gap-x-3 rounded-md p-3 text-base font-semibold leading-relaxed',
-                         'bg-red-600 dark:bg-red-800/20 text-white' => false, // No route yet
-                         'text-red-200 dark:text-red-200/80 hover:text-white hover:bg-red-600 dark:hover:bg-red-700/25' => true
+                         'bg-red-600 dark:bg-red-800/20 text-white' => request()->routeIs('app.stories.*'),
+                         'text-red-200 dark:text-red-200/80 hover:text-white hover:bg-red-600 dark:hover:bg-red-700/25' => !request()->routeIs('app.stories.*')
                        ])>
                       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" data-slot="icon" aria-hidden="true" class="size-6 shrink-0 text-white">
                         <path d="M12 6.042A8.967 8.967 0 006 3.75c-1.052 0-2.062.18-3 .512v14.25A8.987 8.987 0 016 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 016-2.292c1.052 0 2.062.18 3 .512v14.25A8.987 8.987 0 0018 18a8.967 8.967 0 00-6 2.292m0-14.25v14.25" stroke-linecap="round" stroke-linejoin="round" />
@@ -177,12 +177,12 @@
               </a>
             </li>
             <li>
-              <a href="#"
+              <a href="{{ route('app.fantasies.index') }}"
                  wire:navigate
                  @class([
                    'group flex gap-x-3 rounded-md p-2 text-sm/6 font-semibold',
-                   'bg-red-600 dark:bg-red-800/20 text-white' => false, // No route yet
-                   'text-red-200 dark:text-red-200/80 hover:text-white hover:bg-red-600 dark:hover:bg-red-700/25' => true
+                   'bg-red-600 dark:bg-red-800/20 text-white' => request()->routeIs('app.fantasies.*'),
+                   'text-red-200 dark:text-red-200/80 hover:text-white hover:bg-red-600 dark:hover:bg-red-700/25' => !request()->routeIs('app.fantasies.*')
                  ])>
                 <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" data-slot="icon" aria-hidden="true" class="size-6 shrink-0 text-white">
                   <path d="M21 8.25c0-2.485-2.099-4.5-4.688-4.5-1.935 0-3.597 1.126-4.312 2.733-.715-1.607-2.377-2.733-4.313-2.733C5.1 3.75 3 5.765 3 8.25c0 7.22 9 12 9 12s9-4.78 9-12z" stroke-linecap="round" stroke-linejoin="round" />
@@ -191,12 +191,12 @@
               </a>
             </li>
             <li>
-              <a href="#"
+              <a href="{{ route('app.stories.index') }}"
                  wire:navigate
                  @class([
                    'group flex gap-x-3 rounded-md p-2 text-sm/6 font-semibold',
-                   'bg-red-600 dark:bg-red-800/20 text-white' => false, // No route yet
-                   'text-red-200 dark:text-red-200/80 hover:text-white hover:bg-red-600 dark:hover:bg-red-700/25' => true
+                   'bg-red-600 dark:bg-red-800/20 text-white' => request()->routeIs('app.stories.*'),
+                   'text-red-200 dark:text-red-200/80 hover:text-white hover:bg-red-600 dark:hover:bg-red-700/25' => !request()->routeIs('app.stories.*')
                  ])>
                 <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" data-slot="icon" aria-hidden="true" class="size-6 shrink-0 text-white">
                   <path d="M12 6.042A8.967 8.967 0 006 3.75c-1.052 0-2.062.18-3 .512v14.25A8.987 8.987 0 016 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 016-2.292c1.052 0 2.062.18 3 .512v14.25A8.987 8.987 0 0018 18a8.967 8.967 0 00-6 2.292m0-14.25v14.25" stroke-linecap="round" stroke-linejoin="round" />


### PR DESCRIPTION
Update "Fantasies" and "Stories" sidebar links to point to their correct routes and enable active state highlighting.

---
<a href="https://cursor.com/background-agent?bcId=bc-52af6a21-6de8-40d6-b97e-6c61cc14e1da">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-52af6a21-6de8-40d6-b97e-6c61cc14e1da">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

