### PR TITLE
Update story and fantasy seeders to use standard php

### DIFF
--- a/database/seeders/FantasySeeder.php
+++ b/database/seeders/FantasySeeder.php
@@ -55,7 +55,7 @@ class FantasySeeder extends Seeder
                 'user_id' => $users->random()->id,
                 'status' => ContentStatus::Approved->value,
                 'is_premium' => false,
-                'view_count' => fake()->numberBetween(0, 1000),
+                'view_count' => rand(0, 1000),
                 'report_count' => 0,
             ]);
         }

--- a/database/seeders/StorySeeder.php
+++ b/database/seeders/StorySeeder.php
@@ -403,7 +403,7 @@ The transformation has taught me that change is not just possible, but inevitabl
                 'user_id' => $users->random()->id,
                 'status' => ContentStatus::Approved->value,
                 'is_premium' => false,
-                'view_count' => fake()->numberBetween(0, 2000),
+                'view_count' => rand(0, 2000),
                 'report_count' => 0,
             ]);
         }


### PR DESCRIPTION
Replace `fake()->numberBetween()` with `rand()` in story and fantasy seeders to ensure production compatibility.

---
<a href="https://cursor.com/background-agent?bcId=bc-61bc2a6b-4c25-44c9-a52a-4f07a33c6792">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-61bc2a6b-4c25-44c9-a52a-4f07a33c6792">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

