### PR TITLE
Fix lazy loading violation on user profile

### DIFF
--- a/app/Livewire/Fantasies/ListFantasies.php
+++ b/app/Livewire/Fantasies/ListFantasies.php
@@ -24,7 +24,7 @@ class ListFantasies extends Component
     #[Computed]
     public function fantasies(): \Illuminate\Contracts\Pagination\LengthAwarePaginator
     {
-        $query = Fantasy::with(['user', 'reactions'])
+        $query = Fantasy::with(['user.profile', 'reactions'])
             ->approved()
             ->when($this->search, function ($query) {
                 $query->where('content', 'like', '%' . $this->search . '%');

--- a/app/Livewire/Stories/ListStories.php
+++ b/app/Livewire/Stories/ListStories.php
@@ -24,7 +24,7 @@ class ListStories extends Component
     #[Computed]
     public function stories(): \Illuminate\Contracts\Pagination\LengthAwarePaginator
     {
-        $query = Story::with(['user', 'reactions'])
+        $query = Story::with(['user.profile', 'reactions'])
             ->approved()
             ->when($this->search, function ($query) {
                 $query->where(function ($q) {


### PR DESCRIPTION
Eager load `user.profile` relationship to resolve `LazyLoadingViolationException` on fantasy and story pages.

The `display_name` accessor on the `User` model, used in Blade templates, attempts to access the `profile` relationship. Previously, only `user` was eagerly loaded, leading to a lazy loading violation when `profile` was accessed. Adding `user.profile` to the eager loading ensures the relationship is available.

---
<a href="https://cursor.com/background-agent?bcId=bc-49d00a0c-8d60-4519-939e-4a79bc92348f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-49d00a0c-8d60-4519-939e-4a79bc92348f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

