### PR TITLE
Fix view tracking service return type

### DIFF
--- a/app/Services/ViewTrackingService.php
+++ b/app/Services/ViewTrackingService.php
@@ -244,7 +244,7 @@ class ViewTrackingService
     private function hasViewedToday(string $userKey, string $modelType, int $modelId): bool
     {
         $dailyViewedKey = self::DAILY_VIEWED_PREFIX . $userKey . ':' . $modelType . ':' . $modelId . ':' . Carbon::today()->format('Y-m-d');
-        return Redis::exists($dailyViewedKey);
+        return (bool) Redis::exists($dailyViewedKey);
     }
 
     /**


### PR DESCRIPTION
Convert `Redis::exists()` return value to boolean in `hasViewedToday()` to fix a `TypeError`.

The `hasViewedToday()` method was returning an integer (0 or 1) from `Redis::exists()` while its signature declared a boolean return type, leading to a `TypeError` in strict mode. Explicitly casting to `(bool)` resolves this type mismatch.

---
<a href="https://cursor.com/background-agent?bcId=bc-592033cc-7e3e-4b5c-8d83-e08ea5ffb889">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-592033cc-7e3e-4b5c-8d83-e08ea5ffb889">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

