### PR TITLE
Fix fantasy route and hide premium checkbox

### DIFF
--- a/app/Livewire/Fantasies/CreateFantasy.php
+++ b/app/Livewire/Fantasies/CreateFantasy.php
@@ -56,7 +56,7 @@ class CreateFantasy extends Component
         $this->is_premium = false;
 
         // Redirect to fantasies list
-        $this->redirectRoute('fantasies.index');
+        $this->redirectRoute('app.fantasies.index');
     }
 
     public function getWordCount(): int

--- a/resources/views/livewire/fantasies/create-fantasy.blade.php
+++ b/resources/views/livewire/fantasies/create-fantasy.blade.php
@@ -43,8 +43,8 @@
                 </div>
             </div>
 
-            <!-- Premium Option -->
-            <div class="mb-6">
+            <!-- Premium Option - Hidden for now -->
+            {{-- <div class="mb-6">
                 <label class="flex items-center">
                     <input
                         type="checkbox"
@@ -55,7 +55,7 @@
                         Make this a premium fantasy (requires premium subscription)
                     </span>
                 </label>
-            </div>
+            </div> --}}
 
             <!-- Guidelines -->
             <div class="mb-6 p-4 bg-blue-50 dark:bg-blue-900/20 rounded-lg">


### PR DESCRIPTION
Fix route not defined error for fantasy creation and hide the premium checkbox from the create form.

The `CreateFantasy` component was attempting to redirect to `fantasies.index`, but the actual route, due to a Laravel route group prefix, was `app.fantasies.index`. This PR corrects the redirect target. Additionally, the premium checkbox is temporarily commented out as requested.

---
<a href="https://cursor.com/background-agent?bcId=bc-c5e715a0-331d-4775-a779-f26d15b8e457">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c5e715a0-331d-4775-a779-f26d15b8e457">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

