### PR TITLE
Remove premium feature and add draft saving

### DIFF
--- a/app/ContentStatus.php
+++ b/app/ContentStatus.php
@@ -6,6 +6,7 @@ namespace App;
 
 enum ContentStatus: int
 {
+    case Draft = 0;
     case Pending = 1;
     case Approved = 2;
     case InReview = 3;
@@ -14,6 +15,7 @@ enum ContentStatus: int
     public function label(): string
     {
         return match($this) {
+            self::Draft => 'Draft',
             self::Pending => 'Pending Review',
             self::Approved => 'Approved',
             self::InReview => 'Under Review',
@@ -24,6 +26,7 @@ enum ContentStatus: int
     public function color(): string
     {
         return match($this) {
+            self::Draft => 'gray',
             self::Pending => 'yellow',
             self::Approved => 'green',
             self::InReview => 'orange',

--- a/app/Livewire/Stories/CreateStory.php
+++ b/app/Livewire/Stories/CreateStory.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Livewire\Stories;
 
+use App\ContentStatus;
 use App\Models\Story;
 use Illuminate\Contracts\View\View;
 use Illuminate\Support\Facades\Auth;
@@ -47,7 +48,7 @@ class CreateStory extends Component
             'word_count' => $wordCount,
             'reading_time_minutes' => max(1, ceil($wordCount / 200)), // 200 words per minute
             'user_id' => Auth::id(),
-            'status' => 0, // Draft
+            'status' => ContentStatus::Draft,
         ]);
 
         $this->dispatch('show-notification', [
@@ -89,7 +90,7 @@ class CreateStory extends Component
             'word_count' => $wordCount,
             'reading_time_minutes' => max(1, ceil($wordCount / 200)), // 200 words per minute
             'user_id' => Auth::id(),
-            'status' => 1, // Pending approval
+            'status' => ContentStatus::Pending,
         ]);
 
         $this->dispatch('show-notification', [

--- a/app/Livewire/Stories/ListStories.php
+++ b/app/Livewire/Stories/ListStories.php
@@ -18,8 +18,6 @@ class ListStories extends Component
     #[Url]
     public string $search = '';
 
-    #[Url]
-    public bool $showPremium = false;
 
     #[Computed]
     public function stories(): \Illuminate\Contracts\Pagination\LengthAwarePaginator
@@ -32,9 +30,6 @@ class ListStories extends Component
                         ->orWhere('summary', 'like', '%' . $this->search . '%')
                         ->orWhere('content', 'like', '%' . $this->search . '%');
                 });
-            })
-            ->when(!$this->showPremium, function ($query) {
-                $query->where('is_premium', false);
             });
 
         return $query->orderBy('created_at', 'desc')->paginate(12);
@@ -74,15 +69,9 @@ class ListStories extends Component
         $this->resetPage();
     }
 
-    public function updatedShowPremium(): void
-    {
-        $this->resetPage();
-    }
-
     public function clearFilters(): void
     {
         $this->search = '';
-        $this->showPremium = false;
         $this->resetPage();
     }
 

--- a/app/Models/Story.php
+++ b/app/Models/Story.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\ContentStatus;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -37,7 +38,7 @@ class Story extends Model implements ReactableInterface
             'reading_time_minutes' => 'integer',
             'view_count' => 'integer',
             'report_count' => 'integer',
-            'status' => 'integer',
+            'status' => ContentStatus::class,
         ];
     }
 
@@ -93,7 +94,7 @@ class Story extends Model implements ReactableInterface
      */
     public function scopeDraft($query)
     {
-        return $query->where('status', 0);
+        return $query->where('status', ContentStatus::Draft);
     }
 
     /**
@@ -101,7 +102,7 @@ class Story extends Model implements ReactableInterface
      */
     public function scopeApproved($query)
     {
-        return $query->where('status', 2);
+        return $query->where('status', ContentStatus::Approved);
     }
 
     /**
@@ -109,7 +110,7 @@ class Story extends Model implements ReactableInterface
      */
     public function scopePending($query)
     {
-        return $query->where('status', 1);
+        return $query->where('status', ContentStatus::Pending);
     }
 
     /**
@@ -117,7 +118,7 @@ class Story extends Model implements ReactableInterface
      */
     public function scopeRejected($query)
     {
-        return $query->where('status', 4);
+        return $query->where('status', ContentStatus::Rejected);
     }
 
     /**
@@ -125,7 +126,7 @@ class Story extends Model implements ReactableInterface
      */
     public function scopeInReview($query)
     {
-        return $query->where('status', 3);
+        return $query->where('status', ContentStatus::InReview);
     }
 
     /**
@@ -141,14 +142,7 @@ class Story extends Model implements ReactableInterface
      */
     public function getStatusLabelAttribute(): string
     {
-        return match ($this->status) {
-            0 => 'Draft',
-            1 => 'Pending',
-            2 => 'Approved',
-            3 => 'In Review',
-            4 => 'Rejected',
-            default => 'Unknown',
-        };
+        return $this->status->label();
     }
 
     /**
@@ -156,7 +150,7 @@ class Story extends Model implements ReactableInterface
      */
     public function isDraft(): bool
     {
-        return $this->status === 0;
+        return $this->status === ContentStatus::Draft;
     }
 
     /**
@@ -164,7 +158,7 @@ class Story extends Model implements ReactableInterface
      */
     public function isApproved(): bool
     {
-        return $this->status === 2;
+        return $this->status === ContentStatus::Approved;
     }
 
     /**
@@ -172,7 +166,7 @@ class Story extends Model implements ReactableInterface
      */
     public function isPending(): bool
     {
-        return $this->status === 1;
+        return $this->status === ContentStatus::Pending;
     }
 
     /**
@@ -180,7 +174,7 @@ class Story extends Model implements ReactableInterface
      */
     public function isRejected(): bool
     {
-        return $this->status === 4;
+        return $this->status === ContentStatus::Rejected;
     }
 
     /**
@@ -188,7 +182,7 @@ class Story extends Model implements ReactableInterface
      */
     public function isInReview(): bool
     {
-        return $this->status === 3;
+        return $this->status === ContentStatus::InReview;
     }
 
     /**

--- a/app/Models/Story.php
+++ b/app/Models/Story.php
@@ -28,13 +28,11 @@ class Story extends Model implements ReactableInterface
         'status',
         'view_count',
         'report_count',
-        'is_premium',
     ];
 
     protected function casts(): array
     {
         return [
-            'is_premium' => 'boolean',
             'word_count' => 'integer',
             'reading_time_minutes' => 'integer',
             'view_count' => 'integer',
@@ -91,6 +89,14 @@ class Story extends Model implements ReactableInterface
     }
 
     /**
+     * Scope to get draft stories.
+     */
+    public function scopeDraft($query)
+    {
+        return $query->where('status', 0);
+    }
+
+    /**
      * Scope to get approved stories.
      */
     public function scopeApproved($query)
@@ -123,19 +129,11 @@ class Story extends Model implements ReactableInterface
     }
 
     /**
-     * Scope to get public stories (approved and not premium).
+     * Scope to get public stories (approved).
      */
     public function scopePublic($query)
     {
-        return $query->approved()->where('is_premium', false);
-    }
-
-    /**
-     * Scope to get premium stories.
-     */
-    public function scopePremium($query)
-    {
-        return $query->where('is_premium', true);
+        return $query->approved();
     }
 
     /**
@@ -144,12 +142,21 @@ class Story extends Model implements ReactableInterface
     public function getStatusLabelAttribute(): string
     {
         return match ($this->status) {
+            0 => 'Draft',
             1 => 'Pending',
             2 => 'Approved',
             3 => 'In Review',
             4 => 'Rejected',
             default => 'Unknown',
         };
+    }
+
+    /**
+     * Check if the story is a draft.
+     */
+    public function isDraft(): bool
+    {
+        return $this->status === 0;
     }
 
     /**

--- a/database/factories/StoryFactory.php
+++ b/database/factories/StoryFactory.php
@@ -79,7 +79,7 @@ class StoryFactory extends Factory
     public function draft(): static
     {
         return $this->state(fn (array $attributes) => [
-            'status' => 0, // Draft
+            'status' => ContentStatus::Draft,
         ]);
     }
 

--- a/database/factories/StoryFactory.php
+++ b/database/factories/StoryFactory.php
@@ -40,7 +40,6 @@ class StoryFactory extends Factory
             'user_id' => User::factory(),
             'status' => ContentStatus::Approved,
             'report_count' => fake()->numberBetween(0, 5),
-            'is_premium' => fake()->boolean(20), // 20% chance of being premium
         ];
     }
 
@@ -75,12 +74,12 @@ class StoryFactory extends Factory
     }
 
     /**
-     * Create a premium story
+     * Create a draft story
      */
-    public function premium(): static
+    public function draft(): static
     {
         return $this->state(fn (array $attributes) => [
-            'is_premium' => true,
+            'status' => 0, // Draft
         ]);
     }
 

--- a/database/migrations/2025_01_15_000004_update_stories_table_remove_premium_add_draft.php
+++ b/database/migrations/2025_01_15_000004_update_stories_table_remove_premium_add_draft.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('stories', function (Blueprint $table) {
+            // Remove the premium feature
+            $table->dropColumn('is_premium');
+            
+            // Add draft status - 0=draft, 1=pending, 2=approved, 3=in_review, 4=rejected
+            $table->integer('status')->default(0)->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('stories', function (Blueprint $table) {
+            // Add back the premium feature
+            $table->boolean('is_premium')->default(false);
+            
+            // Revert status to original default
+            $table->integer('status')->default(1)->change();
+        });
+    }
+};

--- a/database/migrations/2025_01_15_000004_update_stories_table_remove_premium_add_draft.php
+++ b/database/migrations/2025_01_15_000004_update_stories_table_remove_premium_add_draft.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\ContentStatus;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
@@ -16,7 +17,7 @@ return new class extends Migration
             $table->dropColumn('is_premium');
             
             // Add draft status - 0=draft, 1=pending, 2=approved, 3=in_review, 4=rejected
-            $table->integer('status')->default(0)->change();
+            $table->integer('status')->default(ContentStatus::Draft->value)->change();
         });
     }
 
@@ -30,7 +31,7 @@ return new class extends Migration
             $table->boolean('is_premium')->default(false);
             
             // Revert status to original default
-            $table->integer('status')->default(1)->change();
+            $table->integer('status')->default(ContentStatus::Pending->value)->change();
         });
     }
 };

--- a/resources/views/livewire/stories/create-story.blade.php
+++ b/resources/views/livewire/stories/create-story.blade.php
@@ -80,19 +80,6 @@
                 </div>
             </div>
 
-            <!-- Premium Option -->
-            <div class="mb-6">
-                <label class="flex items-center">
-                    <input
-                        type="checkbox"
-                        wire:model="is_premium"
-                        class="rounded border-gray-300 text-blue-600 shadow-sm focus:border-blue-300 focus:ring focus:ring-blue-200 focus:ring-opacity-50"
-                    >
-                    <span class="ml-2 text-sm text-gray-700 dark:text-gray-300">
-                        Make this a premium story (requires premium subscription)
-                    </span>
-                </label>
-            </div>
 
             <!-- Guidelines -->
             <div class="mb-6 p-4 bg-blue-50 dark:bg-blue-900/20 rounded-lg">
@@ -100,26 +87,41 @@
                 <ul class="text-sm text-blue-700 dark:text-blue-300 space-y-1">
                     <li>• Write engaging and well-structured stories</li>
                     <li>• Keep content respectful and consensual</li>
-                    <li>• Minimum 100 words per story</li>
-                    <li>• All stories are reviewed before publication</li>
+                    <li>• Minimum 100 words required for submission</li>
+                    <li>• Save as draft to continue writing later</li>
+                    <li>• All submitted stories are reviewed before publication</li>
                     <li>• Use proper formatting and paragraphs</li>
                 </ul>
             </div>
 
-            <!-- Submit Button -->
-            <div class="flex items-center justify-end gap-4">
+            <!-- Action Buttons -->
+            <div class="flex items-center justify-between gap-4">
                 <a href="{{ route('app.stories.index') }}" 
                    class="px-4 py-2 text-gray-700 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white transition-colors">
                     Cancel
                 </a>
-                <button
-                    type="submit"
-                    class="bg-blue-600 hover:bg-blue-700 text-white px-6 py-2 rounded-lg font-medium transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-                    wire:loading.attr="disabled"
-                >
-                    <span wire:loading.remove>Submit Story</span>
-                    <span wire:loading>Submitting...</span>
-                </button>
+                <div class="flex items-center gap-3">
+                    <button
+                        type="button"
+                        wire:click="saveAsDraft"
+                        class="bg-gray-600 hover:bg-gray-700 text-white px-6 py-2 rounded-lg font-medium transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                        wire:loading.attr="disabled"
+                        wire:target="saveAsDraft"
+                    >
+                        <span wire:loading.remove wire:target="saveAsDraft">Save as Draft</span>
+                        <span wire:loading wire:target="saveAsDraft">Saving...</span>
+                    </button>
+                    <button
+                        type="button"
+                        wire:click="submitForReview"
+                        class="bg-blue-600 hover:bg-blue-700 text-white px-6 py-2 rounded-lg font-medium transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                        wire:loading.attr="disabled"
+                        wire:target="submitForReview"
+                    >
+                        <span wire:loading.remove wire:target="submitForReview">Submit for Review</span>
+                        <span wire:loading wire:target="submitForReview">Submitting...</span>
+                    </button>
+                </div>
             </div>
         </form>
     </div>

--- a/resources/views/livewire/stories/list-stories.blade.php
+++ b/resources/views/livewire/stories/list-stories.blade.php
@@ -28,17 +28,6 @@
                 >
             </div>
 
-            <!-- Premium Filter -->
-            <div>
-                <label class="flex items-center">
-                    <input
-                        type="checkbox"
-                        wire:model.live="showPremium"
-                        class="rounded border-gray-300 text-blue-600 shadow-sm focus:border-blue-300 focus:ring focus:ring-blue-200 focus:ring-opacity-50"
-                    >
-                    <span class="ml-2 text-sm text-gray-700 dark:text-gray-300">Show Premium</span>
-                </label>
-            </div>
 
             <!-- Clear Filters -->
             <div class="flex items-end">
@@ -90,14 +79,6 @@
                         </span>
                     </div>
 
-                    <!-- Premium Badge -->
-                    @if($story->is_premium)
-                        <div class="mb-4">
-                            <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200">
-                                Premium
-                            </span>
-                        </div>
-                    @endif
 
                     <!-- Read More Button -->
                     <div class="mt-auto">

--- a/resources/views/livewire/stories/show-story.blade.php
+++ b/resources/views/livewire/stories/show-story.blade.php
@@ -46,14 +46,6 @@
             </div>
         </div>
 
-        <!-- Premium Badge -->
-        @if($story->is_premium)
-            <div class="mb-4">
-                <span class="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200">
-                    Premium Story
-                </span>
-            </div>
-        @endif
     </div>
 
     <!-- Story Summary -->

--- a/tests/Feature/Livewire/StoriesTest.php
+++ b/tests/Feature/Livewire/StoriesTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\ContentStatus;
 use App\Livewire\Stories\ListStories;
 use App\Livewire\Stories\CreateStory;
 use App\Livewire\Stories\ShowStory;
@@ -12,7 +13,7 @@ it('can list stories', function () {
     
     Story::factory()->count(3)->create([
         'user_id' => $user->id,
-        'status' => 2, // Approved
+        'status' => ContentStatus::Approved,
     ]);
 
     Livewire::actingAs($user)
@@ -36,7 +37,7 @@ it('can create a story as draft', function () {
         'title' => 'Test Story',
         'summary' => 'This is a test story summary.',
         'user_id' => $user->id,
-        'status' => 0, // Draft
+        'status' => ContentStatus::Draft,
     ]);
 });
 
@@ -55,7 +56,7 @@ it('can submit a story for review', function () {
         'title' => 'Test Story',
         'summary' => 'This is a test story summary.',
         'user_id' => $user->id,
-        'status' => 1, // Pending
+        'status' => ContentStatus::Pending,
     ]);
 });
 
@@ -85,14 +86,14 @@ it('allows saving draft with minimal content', function () {
     $this->assertDatabaseHas('stories', [
         'title' => 'Test Story',
         'user_id' => $user->id,
-        'status' => 0, // Draft
+        'status' => ContentStatus::Draft,
     ]);
 });
 
 it('can show a story', function () {
     $user = User::factory()->create();
     $story = Story::factory()->create([
-        'status' => 2, // Approved
+        'status' => ContentStatus::Approved,
     ]);
     
     Livewire::actingAs($user)
@@ -107,7 +108,7 @@ it('can show a story', function () {
 it('can report a story', function () {
     $user = User::factory()->create();
     $story = Story::factory()->create([
-        'status' => 2, // Approved
+        'status' => ContentStatus::Approved,
     ]);
     
     Livewire::actingAs($user)


### PR DESCRIPTION
Remove the premium story feature and introduce draft functionality, allowing users to save incomplete stories and return to them later.

---
<a href="https://cursor.com/background-agent?bcId=bc-c5113c45-10b3-40aa-b725-b18c75259404">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c5113c45-10b3-40aa-b725-b18c75259404">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

