### PR TITLE
Fix stories index route not found error

### DIFF
--- a/app/Livewire/Stories/CreateStory.php
+++ b/app/Livewire/Stories/CreateStory.php
@@ -60,7 +60,7 @@ class CreateStory extends Component
         $this->resetForm();
 
         // Redirect to stories list
-        $this->redirectRoute('stories.index');
+        $this->redirectRoute('app.stories.index');
     }
 
     public function submitForReview(): void
@@ -102,7 +102,7 @@ class CreateStory extends Component
         $this->resetForm();
 
         // Redirect to stories list
-        $this->redirectRoute('stories.index');
+        $this->redirectRoute('app.stories.index');
     }
 
     private function resetForm(): void

--- a/tests/Feature/Auth/AuthenticatedRoutesTest.php
+++ b/tests/Feature/Auth/AuthenticatedRoutesTest.php
@@ -81,6 +81,6 @@ it('uses correct route names', function () {
     expect(route('app.profile'))->toBe('http://localhost/app/profile');
     expect(route('app.tasks'))->toBe('http://localhost/app/tasks');
     expect(route('app.submit'))->toBe('http://localhost/app/submit');
-    expect(route('app.stories'))->toBe('http://localhost/app/stories');
+    expect(route('app.stories.index'))->toBe('http://localhost/app/stories');
     expect(route('app.settings'))->toBe('http://localhost/app/settings');
 });


### PR DESCRIPTION
Correct route name from `stories.index` to `app.stories.index` to resolve 'Route not defined' error.

The `stories.index` route was defined within a route group that applied an `app.` name prefix, resulting in the full route name being `app.stories.index`. The previous code incorrectly referenced `stories.index`, leading to the `RouteNotFoundException`.

---
<a href="https://cursor.com/background-agent?bcId=bc-34410e2a-447f-4fed-affd-23faaf060b9e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-34410e2a-447f-4fed-affd-23faaf060b9e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

