### PR TITLE
Enable couple login with shared subscription

### DIFF
--- a/app/Http/Middleware/EnsureCoupleSubscription.php
+++ b/app/Http/Middleware/EnsureCoupleSubscription.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class EnsureCoupleSubscription
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        $user = $request->user();
+
+        // If user is not authenticated, let them through (auth middleware will handle this)
+        if (!$user) {
+            return $next($request);
+        }
+
+        // If user is admin, let them through
+        if ($user->hasRole('Admin')) {
+            return $next($request);
+        }
+
+        // If user is part of a couple, check if either partner has an active subscription
+        if ($user->isPartOfCouple()) {
+            // If neither partner has an active subscription, redirect to subscription management
+            if (!$user->hasActiveSubscription()) {
+                return redirect()->route('subscription.manage')
+                    ->with('error', 'Your couple subscription has expired. Please renew to continue accessing the platform.');
+            }
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Livewire/Subscription/ManageSubscription.php
+++ b/app/Livewire/Subscription/ManageSubscription.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Livewire\Subscription;
+
+use Livewire\Component;
+use Illuminate\Support\Facades\Auth;
+
+class ManageSubscription extends Component
+{
+    public function render()
+    {
+        $user = Auth::user();
+        
+        return view('livewire.subscription.manage-subscription', [
+            'user' => $user,
+            'subscriptionStatus' => $user->subscription_status,
+            'isPartOfCouple' => $user->isPartOfCouple(),
+            'partner' => $user->getCouplePartner(),
+        ])->layout('components.layouts.app');
+    }
+
+    public function subscribe()
+    {
+        // Redirect to Stripe checkout or subscription page
+        // This would typically redirect to a Stripe checkout session
+        return redirect()->route('stripe.checkout');
+    }
+
+    public function manageBilling()
+    {
+        // Redirect to Stripe customer portal
+        // This would typically redirect to Stripe customer portal
+        return redirect()->route('stripe.portal');
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -14,7 +14,9 @@ return Application::configure(basePath: dirname(__DIR__))
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware): void {
-        //
+        $middleware->alias([
+            'couple.subscription' => \App\Http\Middleware\EnsureCoupleSubscription::class,
+        ]);
     })
     ->withSchedule(function (Schedule $schedule): void {
         //        $schedule->command('activitylog:clean --days=7')->daily();

--- a/resources/views/livewire/subscription/manage-subscription.blade.php
+++ b/resources/views/livewire/subscription/manage-subscription.blade.php
@@ -1,0 +1,141 @@
+<div class="min-h-screen bg-gray-50 dark:bg-gray-900 py-12">
+    <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div class="bg-white dark:bg-gray-800 shadow rounded-lg">
+            <div class="px-6 py-8">
+                <div class="text-center">
+                    <h1 class="text-3xl font-bold text-gray-900 dark:text-white">
+                        Subscription Management
+                    </h1>
+                    <p class="mt-2 text-gray-600 dark:text-gray-400">
+                        Manage your subscription and billing
+                    </p>
+                </div>
+
+                <div class="mt-8">
+                    <!-- Current Status -->
+                    <div class="bg-gray-50 dark:bg-gray-700 rounded-lg p-6 mb-6">
+                        <h2 class="text-lg font-semibold text-gray-900 dark:text-white mb-4">
+                            Current Status
+                        </h2>
+                        <div class="flex items-center justify-between">
+                            <div>
+                                <p class="text-sm text-gray-600 dark:text-gray-400">Subscription Status</p>
+                                <p class="text-lg font-medium text-gray-900 dark:text-white">
+                                    {{ ucfirst(str_replace('_', ' ', $subscriptionStatus)) }}
+                                </p>
+                            </div>
+                            @if($isPartOfCouple && $partner)
+                                <div class="text-right">
+                                    <p class="text-sm text-gray-600 dark:text-gray-400">Couple Account</p>
+                                    <p class="text-sm font-medium text-gray-900 dark:text-white">
+                                        Partner: {{ $partner->name }}
+                                    </p>
+                                </div>
+                            @endif
+                        </div>
+                    </div>
+
+                    <!-- Subscription Actions -->
+                    <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+                        @if(!$user->hasActiveSubscription())
+                            <!-- No Active Subscription -->
+                            <div class="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg p-6">
+                                <div class="flex items-center">
+                                    <div class="flex-shrink-0">
+                                        <svg class="h-5 w-5 text-red-400" viewBox="0 0 20 20" fill="currentColor">
+                                            <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z" clip-rule="evenodd" />
+                                        </svg>
+                                    </div>
+                                    <div class="ml-3">
+                                        <h3 class="text-sm font-medium text-red-800 dark:text-red-200">
+                                            No Active Subscription
+                                        </h3>
+                                        <div class="mt-2 text-sm text-red-700 dark:text-red-300">
+                                            <p>
+                                                @if($isPartOfCouple)
+                                                    Your couple subscription has expired. Please renew to continue accessing the platform.
+                                                @else
+                                                    You need an active subscription to access premium features.
+                                                @endif
+                                            </p>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="mt-4">
+                                    <button wire:click="subscribe" 
+                                            class="bg-red-600 hover:bg-red-700 text-white px-4 py-2 rounded-md text-sm font-medium">
+                                        Subscribe Now
+                                    </button>
+                                </div>
+                            </div>
+                        @else
+                            <!-- Active Subscription -->
+                            <div class="bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-800 rounded-lg p-6">
+                                <div class="flex items-center">
+                                    <div class="flex-shrink-0">
+                                        <svg class="h-5 w-5 text-green-400" viewBox="0 0 20 20" fill="currentColor">
+                                            <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd" />
+                                        </svg>
+                                    </div>
+                                    <div class="ml-3">
+                                        <h3 class="text-sm font-medium text-green-800 dark:text-green-200">
+                                            Active Subscription
+                                        </h3>
+                                        <div class="mt-2 text-sm text-green-700 dark:text-green-300">
+                                            <p>
+                                                @if($isPartOfCouple)
+                                                    You have access through your couple subscription.
+                                                @else
+                                                    You have an active subscription.
+                                                @endif
+                                            </p>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="mt-4">
+                                    <button wire:click="manageBilling" 
+                                            class="bg-green-600 hover:bg-green-700 text-white px-4 py-2 rounded-md text-sm font-medium">
+                                        Manage Billing
+                                    </button>
+                                </div>
+                            </div>
+                        @endif
+
+                        <!-- Couple Information -->
+                        @if($isPartOfCouple && $partner)
+                            <div class="bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-lg p-6">
+                                <div class="flex items-center">
+                                    <div class="flex-shrink-0">
+                                        <svg class="h-5 w-5 text-blue-400" viewBox="0 0 20 20" fill="currentColor">
+                                            <path d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+                                        </svg>
+                                    </div>
+                                    <div class="ml-3">
+                                        <h3 class="text-sm font-medium text-blue-800 dark:text-blue-200">
+                                            Couple Account
+                                        </h3>
+                                        <div class="mt-2 text-sm text-blue-700 dark:text-blue-300">
+                                            <p>Partner: {{ $partner->name }}</p>
+                                            <p>Email: {{ $partner->email }}</p>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        @endif
+                    </div>
+
+                    <!-- Back to Dashboard -->
+                    <div class="mt-8 text-center">
+                        <a href="{{ route('app.dashboard') }}" 
+                           class="inline-flex items-center px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm text-sm font-medium text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-800 hover:bg-gray-50 dark:hover:bg-gray-700">
+                            <svg class="mr-2 h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 19l-7-7m0 0l7-7m-7 7h18" />
+                            </svg>
+                            Back to Dashboard
+                        </a>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -42,7 +42,7 @@ Route::post('/logout', function () {
 })->middleware('auth')->name('logout');
 
 // Application Routes (Authenticated users only)
-Route::middleware('auth')->prefix('app')->name('app.')->group(function () {
+Route::middleware(['auth', 'couple.subscription'])->prefix('app')->name('app.')->group(function () {
     // Dashboard
     Route::get('/dashboard', Dashboard::class)->name('dashboard');
     
@@ -67,4 +67,9 @@ Route::middleware('auth')->prefix('app')->name('app.')->group(function () {
 
     // Comments Demo
     Route::get('/comments-demo', CommentsDemo::class)->name('comments.demo');
+});
+
+// Subscription Management (Authenticated users only)
+Route::middleware('auth')->group(function () {
+    Route::get('/subscription/manage', \App\Livewire\Subscription\ManageSubscription::class)->name('subscription.manage');
 });

--- a/tests/Feature/CoupleAuthenticationTest.php
+++ b/tests/Feature/CoupleAuthenticationTest.php
@@ -1,0 +1,119 @@
+<?php
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+it('allows user with partner to access platform when partner has active subscription', function () {
+    // Create two users and link them as partners
+    $user1 = User::factory()->create();
+    $user2 = User::factory()->create(['partner_id' => $user1->id]);
+    
+    // Give user1 an active subscription
+    $user1->newSubscription('premium', 'price_premium')->create();
+    
+    // User2 should have access through user1's subscription
+    expect($user2->hasActiveSubscription())->toBeTrue();
+    expect($user2->hasActivePremiumSubscription())->toBeTrue();
+    expect($user2->subscription_status)->toBe('Couple Premium');
+});
+
+it('allows user with partner to access platform when user has active subscription', function () {
+    // Create two users and link them as partners
+    $user1 = User::factory()->create();
+    $user2 = User::factory()->create(['partner_id' => $user1->id]);
+    
+    // Give user2 an active subscription
+    $user2->newSubscription('premium', 'price_premium')->create();
+    
+    // User1 should have access through user2's subscription
+    expect($user1->hasActiveSubscription())->toBeTrue();
+    expect($user1->hasActivePremiumSubscription())->toBeTrue();
+    expect($user1->subscription_status)->toBe('Couple Premium');
+});
+
+it('denies access when neither partner has active subscription', function () {
+    // Create two users and link them as partners
+    $user1 = User::factory()->create();
+    $user2 = User::factory()->create(['partner_id' => $user1->id]);
+    
+    // Neither user has a subscription
+    expect($user1->hasActiveSubscription())->toBeFalse();
+    expect($user2->hasActiveSubscription())->toBeFalse();
+    expect($user1->subscription_status)->toBe('Free');
+    expect($user2->subscription_status)->toBe('Free');
+});
+
+it('correctly identifies couple relationships', function () {
+    // Create two users and link them as partners
+    $user1 = User::factory()->create();
+    $user2 = User::factory()->create(['partner_id' => $user1->id]);
+    
+    // Both users should be part of a couple
+    expect($user1->isPartOfCouple())->toBeTrue();
+    expect($user2->isPartOfCouple())->toBeTrue();
+    
+    // They should be able to get each other as partners
+    expect($user1->getCouplePartner()->id)->toBe($user2->id);
+    expect($user2->getCouplePartner()->id)->toBe($user1->id);
+});
+
+it('handles lifetime subscriptions for couples', function () {
+    // Create two users and link them as partners
+    $user1 = User::factory()->create();
+    $user2 = User::factory()->create(['partner_id' => $user1->id]);
+    
+    // Give user1 a lifetime subscription
+    $user1->newSubscription('lifetime', 'price_lifetime')->create();
+    
+    // User2 should have access through user1's lifetime subscription
+    expect($user2->hasActiveSubscription())->toBeTrue();
+    expect($user2->hasLifetimeSubscription())->toBeTrue();
+    expect($user2->subscription_status)->toBe('Couple Lifetime');
+});
+
+it('redirects to subscription management when couple subscription expires', function () {
+    // Create two users and link them as partners
+    $user1 = User::factory()->create();
+    $user2 = User::factory()->create(['partner_id' => $user1->id]);
+    
+    // Neither user has a subscription
+    $this->actingAs($user2);
+    
+    // Try to access a protected route
+    $response = $this->get('/app/dashboard');
+    
+    // Should redirect to subscription management
+    $response->assertRedirect('/subscription/manage');
+    $response->assertSessionHas('error', 'Your couple subscription has expired. Please renew to continue accessing the platform.');
+});
+
+it('allows access when user has individual subscription', function () {
+    // Create a user with their own subscription
+    $user = User::factory()->create();
+    $user->newSubscription('premium', 'price_premium')->create();
+    
+    $this->actingAs($user);
+    
+    // Should be able to access protected routes
+    $response = $this->get('/app/dashboard');
+    $response->assertStatus(200);
+    
+    expect($user->hasActiveSubscription())->toBeTrue();
+    expect($user->subscription_status)->toBe('Premium');
+});
+
+it('allows admin access regardless of subscription status', function () {
+    // Create an admin user without subscription
+    $admin = User::factory()->create();
+    $admin->assignRole('Admin');
+    
+    $this->actingAs($admin);
+    
+    // Should be able to access protected routes
+    $response = $this->get('/app/dashboard');
+    $response->assertStatus(200);
+    
+    expect($admin->subscription_status)->toBe('Admin');
+});


### PR DESCRIPTION
Implement couple subscription access and management to allow both partners to use the platform if one has an active subscription.

---
<a href="https://cursor.com/background-agent?bcId=bc-d48c2db8-af64-4207-871b-a1971424cd8a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d48c2db8-af64-4207-871b-a1971424cd8a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

