### PR TITLE
Implement status publishing with reactions

### DIFF
--- a/app/Livewire/Components/ReactionButton.php
+++ b/app/Livewire/Components/ReactionButton.php
@@ -9,6 +9,7 @@ use App\Models\Tasks\Task;
 use App\Models\Fantasy;
 use App\Models\Story;
 use App\Models\Comment;
+use App\Models\Status;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Cache;
 use Livewire\Attributes\Locked;
@@ -86,6 +87,7 @@ class ReactionButton extends Component
                 'fantasy', 'fantasies' => Fantasy::find($this->modelId),
                 'story', 'stories' => Story::find($this->modelId),
                 'comment', 'comments' => Comment::find($this->modelId),
+                'status', 'statuses' => Status::find($this->modelId),
                 default => null,
             };
         } catch (\Exception $e) {

--- a/app/Livewire/Status/CreateStatus.php
+++ b/app/Livewire/Status/CreateStatus.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Livewire\Status;
+
+use App\Models\Status;
+use Illuminate\Support\Facades\Auth;
+use Livewire\Attributes\Validate;
+use Livewire\Component;
+
+class CreateStatus extends Component
+{
+    #[Validate('required|string|max:' . Status::getMaxLength())]
+    public string $content = '';
+
+    public bool $isPublic = true;
+
+    public function mount(): void
+    {
+        // Check if user has reached daily limit
+        if ($this->hasReachedDailyLimit()) {
+            $this->dispatch('show-notification', [
+                'message' => 'You have reached your daily status limit.',
+                'type' => 'error',
+            ]);
+        }
+    }
+
+    public function create(): void
+    {
+        $this->validate();
+
+        if (!Auth::check()) {
+            $this->dispatch('show-notification', [
+                'message' => 'Please log in to create a status.',
+                'type' => 'error',
+            ]);
+            return;
+        }
+
+        if ($this->hasReachedDailyLimit()) {
+            $this->dispatch('show-notification', [
+                'message' => 'You have reached your daily status limit.',
+                'type' => 'error',
+            ]);
+            return;
+        }
+
+        $status = Status::create([
+            'content' => $this->content,
+            'user_id' => Auth::id(),
+            'is_public' => $this->isPublic,
+        ]);
+
+        $this->reset(['content']);
+        $this->isPublic = true;
+
+        $this->dispatch('show-notification', [
+            'message' => 'Status created successfully!',
+            'type' => 'success',
+        ]);
+
+        $this->dispatch('status-created', [
+            'statusId' => $status->id,
+        ]);
+    }
+
+    public function getCharacterCountProperty(): int
+    {
+        return strlen($this->content);
+    }
+
+    public function getRemainingCharactersProperty(): int
+    {
+        return max(0, Status::getMaxLength() - $this->characterCount);
+    }
+
+    public function getMaxLengthProperty(): int
+    {
+        return Status::getMaxLength();
+    }
+
+    private function hasReachedDailyLimit(): bool
+    {
+        if (!Auth::check()) {
+            return false;
+        }
+
+        return Auth::user()->hasReachedDailyStatusLimit();
+    }
+
+    public function render()
+    {
+        return view('livewire.status.create-status');
+    }
+}

--- a/app/Livewire/Status/StatusItem.php
+++ b/app/Livewire/Status/StatusItem.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Livewire\Status;
+
+use App\Models\Status;
+use Illuminate\Support\Facades\Auth;
+use Livewire\Attributes\Locked;
+use Livewire\Component;
+
+class StatusItem extends Component
+{
+    #[Locked]
+    public Status $status;
+
+    public bool $showComments = false;
+
+    public function mount(Status $status): void
+    {
+        $this->status = $status;
+    }
+
+    public function toggleComments(): void
+    {
+        $this->showComments = !$this->showComments;
+    }
+
+    public function deleteStatus(): void
+    {
+        if (!Auth::check() || Auth::id() !== $this->status->user_id) {
+            $this->dispatch('show-notification', [
+                'message' => 'You are not authorized to delete this status.',
+                'type' => 'error',
+            ]);
+            return;
+        }
+
+        $this->status->delete();
+
+        $this->dispatch('show-notification', [
+            'message' => 'Status deleted successfully.',
+            'type' => 'success',
+        ]);
+
+        $this->dispatch('status-deleted', [
+            'statusId' => $this->status->id,
+        ]);
+    }
+
+    public function getCanDeleteProperty(): bool
+    {
+        return Auth::check() && Auth::id() === $this->status->user_id;
+    }
+
+    public function getTimeAgoProperty(): string
+    {
+        return $this->status->created_at->diffForHumans();
+    }
+
+    public function getFormattedDateProperty(): string
+    {
+        return $this->status->created_at->format('M j, Y \a\t g:i A');
+    }
+
+    public function render()
+    {
+        return view('livewire.status.status-item');
+    }
+}

--- a/app/Livewire/Status/StatusList.php
+++ b/app/Livewire/Status/StatusList.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Livewire\Status;
+
+use App\Models\Status;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Collection;
+use Livewire\Attributes\Computed;
+use Livewire\Component;
+
+class StatusList extends Component
+{
+    public ?User $user = null;
+    public int $limit = 10;
+    public bool $showCreateForm = false;
+
+    public function mount(?User $user = null, int $limit = 10): void
+    {
+        $this->user = $user;
+        $this->limit = $limit;
+    }
+
+    #[Computed]
+    public function statuses(): Collection
+    {
+        $query = Status::with(['user', 'user.profile'])
+            ->public()
+            ->recent($this->limit);
+
+        if ($this->user) {
+            $query->forUser($this->user);
+        }
+
+        return $query->get();
+    }
+
+    #[Computed]
+    public function canCreateStatus(): bool
+    {
+        return auth()->check() && !$this->hasReachedDailyLimit();
+    }
+
+    #[Computed]
+    public function dailyStatusCount(): int
+    {
+        if (!auth()->check()) {
+            return 0;
+        }
+
+        return auth()->user()->getTodayStatusCount();
+    }
+
+    #[Computed]
+    public function maxStatusesPerDay(): int
+    {
+        return config('app.statuses.max_per_user_per_day', 10);
+    }
+
+    public function toggleCreateForm(): void
+    {
+        if (!$this->canCreateStatus) {
+            $this->dispatch('show-notification', [
+                'message' => 'You have reached your daily status limit.',
+                'type' => 'error',
+            ]);
+            return;
+        }
+
+        $this->showCreateForm = !$this->showCreateForm;
+    }
+
+    public function refreshStatuses(): void
+    {
+        $this->dispatch('$refresh');
+    }
+
+    private function hasReachedDailyLimit(): bool
+    {
+        if (!auth()->check()) {
+            return false;
+        }
+
+        return auth()->user()->hasReachedDailyStatusLimit();
+    }
+
+    public function render()
+    {
+        return view('livewire.status.status-list');
+    }
+}

--- a/app/Livewire/User/PublicProfile.php
+++ b/app/Livewire/User/PublicProfile.php
@@ -118,6 +118,15 @@ class PublicProfile extends Component
         return $this->profile?->about;
     }
 
+    #[Computed]
+    public function recentStatuses($limit = 5)
+    {
+        return $this->user->statuses()
+            ->public()
+            ->recent($limit)
+            ->get();
+    }
+
     public function render()
     {
         return view('livewire.user.public-profile')

--- a/app/Models/Status.php
+++ b/app/Models/Status.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\SoftDeletes;
+use Qirolab\Laravel\Reactions\Contracts\ReactableInterface;
+use Qirolab\Laravel\Reactions\Traits\Reactable;
+use Spatie\Activitylog\LogOptions;
+use Spatie\Activitylog\Traits\LogsActivity;
+
+class Status extends Model implements ReactableInterface
+{
+    use HasFactory, Reactable, LogsActivity, SoftDeletes;
+
+    protected $fillable = [
+        'content',
+        'user_id',
+        'is_public',
+    ];
+
+    protected $casts = [
+        'is_public' => 'boolean',
+    ];
+
+    protected $with = ['user'];
+
+    /**
+     * Get the user who created the status.
+     */
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    /**
+     * Get the comments for this status.
+     */
+    public function comments(): HasMany
+    {
+        return $this->hasMany(Comment::class, 'commentable_id')
+            ->where('commentable_type', self::class)
+            ->approved()
+            ->orderBy('created_at', 'asc');
+    }
+
+    /**
+     * Get all comments for this status (including unapproved).
+     */
+    public function allComments(): HasMany
+    {
+        return $this->hasMany(Comment::class, 'commentable_id')
+            ->where('commentable_type', self::class)
+            ->orderBy('created_at', 'asc');
+    }
+
+    /**
+     * Scope to get only public statuses.
+     */
+    public function scopePublic($query)
+    {
+        return $query->where('is_public', true);
+    }
+
+    /**
+     * Scope to get statuses for a specific user.
+     */
+    public function scopeForUser($query, User $user)
+    {
+        return $query->where('user_id', $user->id);
+    }
+
+    /**
+     * Scope to get recent statuses.
+     */
+    public function scopeRecent($query, int $limit = 10)
+    {
+        return $query->orderBy('created_at', 'desc')->limit($limit);
+    }
+
+    /**
+     * Get the maximum character limit for status content.
+     */
+    public static function getMaxLength(): int
+    {
+        return config('app.statuses.max_length', 280);
+    }
+
+    /**
+     * Check if the status content is within the character limit.
+     */
+    public function isWithinLimit(): bool
+    {
+        return strlen($this->content) <= self::getMaxLength();
+    }
+
+    /**
+     * Get the character count for the status content.
+     */
+    public function getCharacterCountAttribute(): int
+    {
+        return strlen($this->content);
+    }
+
+    /**
+     * Get the remaining characters available.
+     */
+    public function getRemainingCharactersAttribute(): int
+    {
+        return max(0, self::getMaxLength() - $this->character_count);
+    }
+
+    /**
+     * Get activity log options.
+     */
+    public function getActivitylogOptions(): LogOptions
+    {
+        return LogOptions::defaults()
+            ->logOnly(['content', 'is_public'])
+            ->logOnlyDirty()
+            ->dontSubmitEmptyLogs();
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -195,6 +195,37 @@ class User extends Authenticatable implements FilamentUser, HasPassKeys, ReactsI
     }
 
     /**
+     * Get the user's statuses
+     */
+    public function statuses(): HasMany
+    {
+        return $this->hasMany(\App\Models\Status::class);
+    }
+
+    /**
+     * Check if user has reached their daily status limit
+     */
+    public function hasReachedDailyStatusLimit(): bool
+    {
+        $maxPerDay = config('app.statuses.max_per_user_per_day', 10);
+        $todayCount = $this->statuses()
+            ->whereDate('created_at', today())
+            ->count();
+
+        return $todayCount >= $maxPerDay;
+    }
+
+    /**
+     * Get the number of statuses created today
+     */
+    public function getTodayStatusCount(): int
+    {
+        return $this->statuses()
+            ->whereDate('created_at', today())
+            ->count();
+    }
+
+    /**
      * Get the user's recent task activities
      */
     public function recentTaskActivities(int $limit = 10): HasMany

--- a/config/app.php
+++ b/config/app.php
@@ -159,4 +159,18 @@ return [
         ],
     ],
 
+    /*
+    |--------------------------------------------------------------------------
+    | Status System Configuration
+    |--------------------------------------------------------------------------
+    |
+    | Configuration for the user status system.
+    |
+    */
+
+    'statuses' => [
+        'max_length' => env('STATUS_MAX_LENGTH', 280),
+        'max_per_user_per_day' => env('STATUS_MAX_PER_USER_PER_DAY', 10),
+    ],
+
 ];

--- a/database/factories/StatusFactory.php
+++ b/database/factories/StatusFactory.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Status;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Status>
+ */
+class StatusFactory extends Factory
+{
+    /**
+     * The name of the factory's corresponding model.
+     *
+     * @var string
+     */
+    protected $model = Status::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'user_id' => User::factory(),
+            'content' => $this->faker->paragraph(2),
+            'is_public' => $this->faker->boolean(80), // 80% chance of being public
+        ];
+    }
+
+    /**
+     * Indicate that the status is public.
+     */
+    public function public(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'is_public' => true,
+        ]);
+    }
+
+    /**
+     * Indicate that the status is private.
+     */
+    public function private(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'is_public' => false,
+        ]);
+    }
+
+    /**
+     * Create a status with specific content length.
+     */
+    public function withLength(int $length): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'content' => $this->faker->text($length),
+        ]);
+    }
+
+    /**
+     * Create a status with maximum allowed length.
+     */
+    public function maxLength(): static
+    {
+        $maxLength = Status::getMaxLength();
+        return $this->state(fn (array $attributes) => [
+            'content' => $this->faker->text($maxLength),
+        ]);
+    }
+}

--- a/database/migrations/2025_01_15_000006_create_statuses_table.php
+++ b/database/migrations/2025_01_15_000006_create_statuses_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('statuses', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->onDelete('cascade');
+            $table->text('content');
+            $table->boolean('is_public')->default(true);
+            $table->timestamps();
+            $table->softDeletes();
+
+            $table->index(['user_id', 'created_at']);
+            $table->index(['is_public', 'created_at']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('statuses');
+    }
+};

--- a/database/seeders/StatusSeeder.php
+++ b/database/seeders/StatusSeeder.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Status;
+use App\Models\User;
+use Illuminate\Database\Seeder;
+
+class StatusSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        // Get some users to create statuses for
+        $users = User::take(5)->get();
+
+        if ($users->isEmpty()) {
+            $this->command->info('No users found. Please run UserSeeder first.');
+            return;
+        }
+
+        // Create some sample statuses
+        $sampleStatuses = [
+            'Just completed an amazing task! Feeling accomplished! 🎉',
+            'The community here is so supportive. Love being part of this!',
+            'New to this platform but already loving the experience.',
+            'Task completed successfully! Ready for the next challenge.',
+            'This platform has really helped me stay motivated.',
+            'Sharing my progress with everyone. We\'re all in this together!',
+            'Another day, another task completed. Consistency is key!',
+            'The rewards system here is fantastic. Highly recommend!',
+            'Feeling proud of my progress this week.',
+            'Thank you to everyone who has been supportive!',
+        ];
+
+        foreach ($users as $user) {
+            // Create 2-4 statuses per user
+            $statusCount = rand(2, 4);
+            
+            for ($i = 0; $i < $statusCount; $i++) {
+                Status::factory()->create([
+                    'user_id' => $user->id,
+                    'content' => $sampleStatuses[array_rand($sampleStatuses)],
+                    'is_public' => rand(0, 100) < 85, // 85% chance of being public
+                    'created_at' => now()->subDays(rand(0, 7)), // Random time in last week
+                ]);
+            }
+        }
+
+        $this->command->info('Created sample statuses for users.');
+    }
+}

--- a/docs/STATUS_FEATURE.md
+++ b/docs/STATUS_FEATURE.md
@@ -1,0 +1,151 @@
+# Status Feature Documentation
+
+## Overview
+
+The Status feature allows users to publish short text updates (280 characters by default) to their profile, similar to Facebook status updates. Other users can react to these statuses, and the comment system is prepared but currently disabled.
+
+## Features
+
+### Core Functionality
+- **Status Creation**: Users can create status updates up to 280 characters (configurable)
+- **Public/Private**: Statuses can be marked as public or private
+- **Daily Limits**: Users are limited to 10 statuses per day (configurable)
+- **Reactions**: Users can react to statuses using the existing reaction system
+- **Comments**: Comment system is prepared but disabled (as requested)
+
+### User Interface
+- **Status List**: Displays recent statuses on user profiles
+- **Create Form**: Toggle-able form for creating new statuses
+- **Character Counter**: Shows current character count and remaining characters
+- **Time Display**: Shows relative time (e.g., "2 hours ago")
+- **Delete Functionality**: Users can delete their own statuses
+
+## Configuration
+
+The status system can be configured in `config/app.php`:
+
+```php
+'statuses' => [
+    'max_length' => env('STATUS_MAX_LENGTH', 280),
+    'max_per_user_per_day' => env('STATUS_MAX_PER_USER_PER_DAY', 10),
+],
+```
+
+Environment variables:
+- `STATUS_MAX_LENGTH`: Maximum characters per status (default: 280)
+- `STATUS_MAX_PER_USER_PER_DAY`: Maximum statuses per user per day (default: 10)
+
+## Database Schema
+
+### Statuses Table
+```sql
+CREATE TABLE statuses (
+    id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    user_id BIGINT UNSIGNED NOT NULL,
+    content TEXT NOT NULL,
+    is_public BOOLEAN DEFAULT TRUE,
+    created_at TIMESTAMP NULL,
+    updated_at TIMESTAMP NULL,
+    deleted_at TIMESTAMP NULL,
+    
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+    INDEX idx_user_created (user_id, created_at),
+    INDEX idx_public_created (is_public, created_at)
+);
+```
+
+## Models
+
+### Status Model
+- **Relationships**: Belongs to User, has many Comments
+- **Scopes**: `public()`, `forUser()`, `recent()`
+- **Methods**: `isWithinLimit()`, `getMaxLength()`
+- **Traits**: `Reactable`, `LogsActivity`, `SoftDeletes`
+
+### User Model Extensions
+- **Relationships**: `statuses()` - has many Status
+- **Methods**: `hasReachedDailyStatusLimit()`, `getTodayStatusCount()`
+
+## Livewire Components
+
+### CreateStatus
+- Handles status creation form
+- Validates content length and daily limits
+- Provides character counting
+- Shows success/error notifications
+
+### StatusList
+- Displays list of statuses for a user
+- Shows create form toggle for authenticated users
+- Handles daily limit display
+- Manages status creation and display
+
+### StatusItem
+- Displays individual status
+- Shows user info, content, and timestamp
+- Handles status deletion
+- Integrates with reaction system
+
+## Testing
+
+The feature includes comprehensive tests:
+
+### Feature Tests
+- Status creation and validation
+- Daily limit enforcement
+- User authorization
+- Character counting
+- Public/private visibility
+
+### Unit Tests
+- Model relationships and scopes
+- Character limit validation
+- Soft delete functionality
+- Configuration handling
+
+### Integration Tests
+- End-to-end status creation and display
+- User profile integration
+- Daily limit enforcement
+- Status deletion
+
+## Usage Examples
+
+### Creating a Status
+```php
+$user = User::find(1);
+$status = Status::create([
+    'user_id' => $user->id,
+    'content' => 'Hello, world!',
+    'is_public' => true,
+]);
+```
+
+### Getting User's Statuses
+```php
+$user = User::find(1);
+$publicStatuses = $user->statuses()->public()->recent(10)->get();
+```
+
+### Checking Daily Limit
+```php
+$user = User::find(1);
+if ($user->hasReachedDailyStatusLimit()) {
+    // Handle limit reached
+}
+```
+
+## Future Enhancements
+
+The comment system is already prepared and can be easily enabled by:
+1. Removing the `disabled` attribute from the comments button
+2. Adding the comment form and list components
+3. Updating the StatusItem component to handle comment display
+
+Other potential enhancements:
+- Status editing
+- Status sharing
+- Status search
+- Status categories/tags
+- Media attachments
+- Status scheduling

--- a/resources/views/livewire/status/create-status.blade.php
+++ b/resources/views/livewire/status/create-status.blade.php
@@ -1,0 +1,58 @@
+<div class="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 p-6">
+    <div class="flex items-start space-x-3">
+        <img 
+            src="{{ auth()->user()->profile_picture_url }}" 
+            alt="{{ auth()->user()->display_name }}"
+            class="w-10 h-10 rounded-full object-cover"
+        >
+        <div class="flex-1">
+            <form wire:submit="create" class="space-y-4">
+                <div>
+                    <textarea
+                        wire:model="content"
+                        placeholder="What's on your mind?"
+                        class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent dark:bg-gray-700 dark:text-white resize-none"
+                        rows="3"
+                        maxlength="{{ $this->maxLength }}"
+                    ></textarea>
+                    
+                    @error('content')
+                        <p class="mt-1 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
+                    @enderror
+                </div>
+
+                <div class="flex items-center justify-between">
+                    <div class="flex items-center space-x-4">
+                        <label class="flex items-center">
+                            <input 
+                                type="checkbox" 
+                                wire:model="isPublic"
+                                class="rounded border-gray-300 text-blue-600 shadow-sm focus:border-blue-300 focus:ring focus:ring-blue-200 focus:ring-opacity-50"
+                            >
+                            <span class="ml-2 text-sm text-gray-600 dark:text-gray-400">Public</span>
+                        </label>
+                    </div>
+
+                    <div class="flex items-center space-x-3">
+                        <span class="text-sm text-gray-500 dark:text-gray-400">
+                            <span class="{{ $this->remainingCharacters < 20 ? 'text-red-500' : 'text-gray-500' }}">
+                                {{ $this->characterCount }}
+                            </span>
+                            / {{ $this->maxLength }}
+                        </span>
+                        
+                        <button
+                            type="submit"
+                            class="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                            wire:loading.attr="disabled"
+                            wire:target="create"
+                        >
+                            <span wire:loading.remove wire:target="create">Post</span>
+                            <span wire:loading wire:target="create">Posting...</span>
+                        </button>
+                    </div>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>

--- a/resources/views/livewire/status/status-item.blade.php
+++ b/resources/views/livewire/status/status-item.blade.php
@@ -1,0 +1,75 @@
+<div class="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 p-6">
+    <div class="flex items-start space-x-3">
+        <img 
+            src="{{ $status->user->profile_picture_url }}" 
+            alt="{{ $status->user->display_name }}"
+            class="w-10 h-10 rounded-full object-cover"
+        >
+        
+        <div class="flex-1 min-w-0">
+            <div class="flex items-center space-x-2">
+                <h3 class="font-medium text-gray-900 dark:text-white">
+                    {{ $status->user->display_name }}
+                </h3>
+                <span class="text-sm text-gray-500 dark:text-gray-400">•</span>
+                <time 
+                    class="text-sm text-gray-500 dark:text-gray-400"
+                    title="{{ $this->formattedDate }}"
+                >
+                    {{ $this->timeAgo }}
+                </time>
+                
+                @if($status->is_public)
+                    <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200">
+                        Public
+                    </span>
+                @else
+                    <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-200">
+                        Private
+                    </span>
+                @endif
+            </div>
+            
+            <div class="mt-2">
+                <p class="text-gray-900 dark:text-white whitespace-pre-wrap">{{ $status->content }}</p>
+            </div>
+            
+            <div class="mt-4 flex items-center justify-between">
+                <div class="flex items-center space-x-4">
+                    <!-- Reaction Button -->
+                    <livewire:components.reaction-button 
+                        :model-type="'status'" 
+                        :model-id="$status->id" 
+                    />
+                    
+                    <!-- Comments Button (Disabled for now) -->
+                    <button
+                        disabled
+                        class="flex items-center space-x-1 text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                        title="Comments coming soon"
+                    >
+                        <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z"></path>
+                        </svg>
+                        <span class="text-sm">Comments</span>
+                    </button>
+                </div>
+                
+                @if($this->canDelete)
+                    <div class="flex items-center space-x-2">
+                        <button
+                            wire:click="deleteStatus"
+                            wire:confirm="Are you sure you want to delete this status?"
+                            class="text-red-500 hover:text-red-700 dark:text-red-400 dark:hover:text-red-300 transition-colors"
+                            title="Delete status"
+                        >
+                            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"></path>
+                            </svg>
+                        </button>
+                    </div>
+                @endif
+            </div>
+        </div>
+    </div>
+</div>

--- a/resources/views/livewire/status/status-list.blade.php
+++ b/resources/views/livewire/status/status-list.blade.php
@@ -1,0 +1,47 @@
+<div class="space-y-6">
+    @if(auth()->check())
+        <div class="flex items-center justify-between">
+            <h2 class="text-xl font-semibold text-gray-900 dark:text-white">Status Updates</h2>
+            
+            @if($this->canCreateStatus)
+                <button
+                    wire:click="toggleCreateForm"
+                    class="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 transition-colors"
+                >
+                    <span wire:loading.remove wire:target="toggleCreateForm">
+                        {{ $showCreateForm ? 'Cancel' : 'New Status' }}
+                    </span>
+                    <span wire:loading wire:target="toggleCreateForm">Loading...</span>
+                </button>
+            @else
+                <div class="text-sm text-gray-500 dark:text-gray-400">
+                    Daily limit reached ({{ $this->dailyStatusCount }}/{{ $this->maxStatusesPerDay }})
+                </div>
+            @endif
+        </div>
+
+        @if($showCreateForm)
+            <livewire:status.create-status />
+        @endif
+    @else
+        <h2 class="text-xl font-semibold text-gray-900 dark:text-white">Status Updates</h2>
+    @endif
+
+    @if($this->statuses->count() > 0)
+        <div class="space-y-4">
+            @foreach($this->statuses as $status)
+                <livewire:status.status-item :status="$status" :key="$status->id" />
+            @endforeach
+        </div>
+    @else
+        <div class="text-center py-8">
+            <div class="text-gray-500 dark:text-gray-400">
+                @if($user)
+                    {{ $user->display_name }} hasn't posted any status updates yet.
+                @else
+                    No status updates to show.
+                @endif
+            </div>
+        </div>
+    @endif
+</div>

--- a/resources/views/livewire/user/public-profile.blade.php
+++ b/resources/views/livewire/user/public-profile.blade.php
@@ -80,6 +80,11 @@
             </div>
         </div>
 
+        <!-- Status Updates -->
+        <div class="mb-6">
+            <livewire:status.status-list :user="$this->user" :limit="10" />
+        </div>
+
         <!-- Recent Activity -->
         <div class="bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-200 dark:border-gray-700 p-6">
             <h2 class="text-xl font-semibold text-gray-900 dark:text-white mb-4">Recent Activity</h2>

--- a/tests/Feature/StatusIntegrationTest.php
+++ b/tests/Feature/StatusIntegrationTest.php
@@ -1,0 +1,124 @@
+<?php
+
+use App\Livewire\Status\StatusList;
+use App\Models\Status;
+use App\Models\User;
+use Livewire\Livewire;
+
+it('can create and display statuses on user profile', function () {
+    $user = User::factory()->create();
+    $otherUser = User::factory()->create();
+
+    // Create some statuses for the user
+    $status1 = Status::factory()->create([
+        'user_id' => $user->id,
+        'content' => 'My first status update!',
+        'is_public' => true,
+    ]);
+
+    $status2 = Status::factory()->create([
+        'user_id' => $user->id,
+        'content' => 'Another status update',
+        'is_public' => true,
+    ]);
+
+    // Create a private status that shouldn't show
+    Status::factory()->create([
+        'user_id' => $user->id,
+        'content' => 'This is private',
+        'is_public' => false,
+    ]);
+
+    // Test the status list component
+    Livewire::test(StatusList::class, ['user' => $user])
+        ->assertSee('My first status update!')
+        ->assertSee('Another status update')
+        ->assertDontSee('This is private')
+        ->assertSee($user->display_name);
+});
+
+it('shows create form for authenticated users', function () {
+    $user = User::factory()->create();
+
+    Livewire::actingAs($user)
+        ->test(StatusList::class)
+        ->assertSee('New Status')
+        ->call('toggleCreateForm')
+        ->assertSee('Cancel')
+        ->assertSee('What\'s on your mind?');
+});
+
+it('does not show create form for unauthenticated users', function () {
+    Livewire::test(StatusList::class)
+        ->assertDontSee('New Status');
+});
+
+it('enforces daily limit correctly', function () {
+    $user = User::factory()->create();
+    $maxPerDay = config('app.statuses.max_per_user_per_day', 10);
+
+    // Create the maximum number of statuses
+    Status::factory()->count($maxPerDay)->create([
+        'user_id' => $user->id,
+        'created_at' => now(),
+    ]);
+
+    Livewire::actingAs($user)
+        ->test(StatusList::class)
+        ->assertSee("Daily limit reached ({$maxPerDay}/{$maxPerDay})")
+        ->assertDontSee('New Status');
+});
+
+it('shows character count and limit correctly', function () {
+    $user = User::factory()->create();
+    $maxLength = Status::getMaxLength();
+
+    Livewire::actingAs($user)
+        ->test(StatusList::class)
+        ->call('toggleCreateForm')
+        ->assertSee("0 / {$maxLength}");
+});
+
+it('can delete own statuses', function () {
+    $user = User::factory()->create();
+    $status = Status::factory()->create([
+        'user_id' => $user->id,
+        'content' => 'This will be deleted',
+    ]);
+
+    Livewire::actingAs($user)
+        ->test(StatusList::class, ['user' => $user])
+        ->assertSee('This will be deleted')
+        ->call('$refresh'); // Refresh to get the StatusItem component
+
+    // The status should be soft deleted
+    expect(Status::find($status->id))->toBeNull();
+    expect(Status::withTrashed()->find($status->id))->not->toBeNull();
+});
+
+it('shows status timestamps correctly', function () {
+    $status = Status::factory()->create([
+        'created_at' => now()->subHours(3),
+    ]);
+
+    Livewire::test(StatusList::class, ['user' => $status->user])
+        ->assertSee('3 hours ago');
+});
+
+it('shows public/private status indicators', function () {
+    $user = User::factory()->create();
+    
+    $publicStatus = Status::factory()->create([
+        'user_id' => $user->id,
+        'is_public' => true,
+    ]);
+
+    $privateStatus = Status::factory()->create([
+        'user_id' => $user->id,
+        'is_public' => false,
+    ]);
+
+    Livewire::test(StatusList::class, ['user' => $user])
+        ->assertSee('Public')
+        ->assertDontSee('Private'); // Private statuses shouldn't show in public list
+});

--- a/tests/Feature/StatusTest.php
+++ b/tests/Feature/StatusTest.php
@@ -1,0 +1,217 @@
+<?php
+
+use App\Livewire\Status\CreateStatus;
+use App\Livewire\Status\StatusList;
+use App\Livewire\Status\StatusItem;
+use App\Models\Status;
+use App\Models\User;
+use Livewire\Livewire;
+
+it('can create a status when authenticated', function () {
+    $user = User::factory()->create();
+
+    Livewire::actingAs($user)
+        ->test(CreateStatus::class)
+        ->set('content', 'This is my first status!')
+        ->set('isPublic', true)
+        ->call('create')
+        ->assertNotified()
+        ->assertSet('content', '');
+
+    $this->assertDatabaseHas('statuses', [
+        'user_id' => $user->id,
+        'content' => 'This is my first status!',
+        'is_public' => true,
+    ]);
+});
+
+it('cannot create a status when not authenticated', function () {
+    Livewire::test(CreateStatus::class)
+        ->set('content', 'This should not work')
+        ->call('create')
+        ->assertDispatched('show-notification', [
+            'message' => 'Please log in to create a status.',
+            'type' => 'error',
+        ]);
+
+    $this->assertDatabaseMissing('statuses', [
+        'content' => 'This should not work',
+    ]);
+});
+
+it('validates status content is required', function () {
+    $user = User::factory()->create();
+
+    Livewire::actingAs($user)
+        ->test(CreateStatus::class)
+        ->set('content', '')
+        ->call('create')
+        ->assertHasErrors(['content' => 'required']);
+});
+
+it('validates status content length', function () {
+    $user = User::factory()->create();
+    $maxLength = Status::getMaxLength();
+    $longContent = str_repeat('a', $maxLength + 1);
+
+    Livewire::actingAs($user)
+        ->test(CreateStatus::class)
+        ->set('content', $longContent)
+        ->call('create')
+        ->assertHasErrors(['content' => 'max']);
+});
+
+it('can create a status with maximum allowed length', function () {
+    $user = User::factory()->create();
+    $maxLength = Status::getMaxLength();
+    $maxContent = str_repeat('a', $maxLength);
+
+    Livewire::actingAs($user)
+        ->test(CreateStatus::class)
+        ->set('content', $maxContent)
+        ->call('create')
+        ->assertNotified();
+
+    $this->assertDatabaseHas('statuses', [
+        'user_id' => $user->id,
+        'content' => $maxContent,
+    ]);
+});
+
+it('enforces daily status limit', function () {
+    $user = User::factory()->create();
+    $maxPerDay = config('app.statuses.max_per_user_per_day', 10);
+
+    // Create the maximum number of statuses for today
+    Status::factory()->count($maxPerDay)->create([
+        'user_id' => $user->id,
+        'created_at' => now(),
+    ]);
+
+    Livewire::actingAs($user)
+        ->test(CreateStatus::class)
+        ->set('content', 'This should be blocked')
+        ->call('create')
+        ->assertDispatched('show-notification', [
+            'message' => 'You have reached your daily status limit.',
+            'type' => 'error',
+        ]);
+
+    $this->assertDatabaseMissing('statuses', [
+        'content' => 'This should be blocked',
+    ]);
+});
+
+it('can display status list', function () {
+    $user = User::factory()->create();
+    $statuses = Status::factory()->count(3)->create([
+        'user_id' => $user->id,
+        'is_public' => true,
+    ]);
+
+    Livewire::test(StatusList::class, ['user' => $user])
+        ->assertSee($statuses->first()->content)
+        ->assertSee($user->display_name);
+});
+
+it('only shows public statuses in status list', function () {
+    $user = User::factory()->create();
+    $publicStatus = Status::factory()->create([
+        'user_id' => $user->id,
+        'is_public' => true,
+        'content' => 'This is public',
+    ]);
+    $privateStatus = Status::factory()->create([
+        'user_id' => $user->id,
+        'is_public' => false,
+        'content' => 'This is private',
+    ]);
+
+    Livewire::test(StatusList::class, ['user' => $user])
+        ->assertSee('This is public')
+        ->assertDontSee('This is private');
+});
+
+it('can delete own status', function () {
+    $user = User::factory()->create();
+    $status = Status::factory()->create([
+        'user_id' => $user->id,
+    ]);
+
+    Livewire::actingAs($user)
+        ->test(StatusItem::class, ['status' => $status])
+        ->call('deleteStatus')
+        ->assertNotified();
+
+    $this->assertSoftDeleted('statuses', [
+        'id' => $status->id,
+    ]);
+});
+
+it('cannot delete another users status', function () {
+    $user = User::factory()->create();
+    $otherUser = User::factory()->create();
+    $status = Status::factory()->create([
+        'user_id' => $otherUser->id,
+    ]);
+
+    Livewire::actingAs($user)
+        ->test(StatusItem::class, ['status' => $status])
+        ->call('deleteStatus')
+        ->assertDispatched('show-notification', [
+            'message' => 'You are not authorized to delete this status.',
+            'type' => 'error',
+        ]);
+
+    $this->assertDatabaseHas('statuses', [
+        'id' => $status->id,
+    ]);
+});
+
+it('shows character count correctly', function () {
+    $user = User::factory()->create();
+    $content = 'Hello world!';
+
+    Livewire::actingAs($user)
+        ->test(CreateStatus::class)
+        ->set('content', $content)
+        ->assertSet('characterCount', strlen($content))
+        ->assertSet('remainingCharacters', Status::getMaxLength() - strlen($content));
+});
+
+it('shows time ago correctly', function () {
+    $status = Status::factory()->create([
+        'created_at' => now()->subHours(2),
+    ]);
+
+    Livewire::test(StatusItem::class, ['status' => $status])
+        ->assertSee('2 hours ago');
+});
+
+it('can toggle create form visibility', function () {
+    $user = User::factory()->create();
+
+    Livewire::actingAs($user)
+        ->test(StatusList::class)
+        ->assertSet('showCreateForm', false)
+        ->call('toggleCreateForm')
+        ->assertSet('showCreateForm', true)
+        ->call('toggleCreateForm')
+        ->assertSet('showCreateForm', false);
+});
+
+it('shows daily limit message when reached', function () {
+    $user = User::factory()->create();
+    $maxPerDay = config('app.statuses.max_per_user_per_day', 10);
+
+    // Create the maximum number of statuses for today
+    Status::factory()->count($maxPerDay)->create([
+        'user_id' => $user->id,
+        'created_at' => now(),
+    ]);
+
+    Livewire::actingAs($user)
+        ->test(StatusList::class)
+        ->assertSee("Daily limit reached ({$maxPerDay}/{$maxPerDay})")
+        ->assertSet('canCreateStatus', false);
+});

--- a/tests/Unit/StatusModelTest.php
+++ b/tests/Unit/StatusModelTest.php
@@ -1,0 +1,134 @@
+<?php
+
+use App\Models\Status;
+use App\Models\User;
+
+it('belongs to a user', function () {
+    $user = User::factory()->create();
+    $status = Status::factory()->create(['user_id' => $user->id]);
+
+    expect($status->user)->toBeInstanceOf(User::class);
+    expect($status->user->id)->toBe($user->id);
+});
+
+it('has correct fillable attributes', function () {
+    $status = new Status();
+    $fillable = ['content', 'user_id', 'is_public'];
+
+    expect($status->getFillable())->toBe($fillable);
+});
+
+it('casts is_public to boolean', function () {
+    $status = Status::factory()->create(['is_public' => 1]);
+
+    expect($status->is_public)->toBeTrue();
+    expect($status->getAttributes()['is_public'])->toBe(1);
+});
+
+it('has default max length configuration', function () {
+    expect(Status::getMaxLength())->toBe(280);
+});
+
+it('can check if content is within limit', function () {
+    $status = Status::factory()->create(['content' => str_repeat('a', 100)]);
+    
+    expect($status->isWithinLimit())->toBeTrue();
+
+    $longStatus = Status::factory()->create(['content' => str_repeat('a', 500)]);
+    expect($longStatus->isWithinLimit())->toBeFalse();
+});
+
+it('calculates character count correctly', function () {
+    $content = 'Hello, world!';
+    $status = Status::factory()->create(['content' => $content]);
+
+    expect($status->character_count)->toBe(strlen($content));
+});
+
+it('calculates remaining characters correctly', function () {
+    $content = 'Hello, world!';
+    $status = Status::factory()->create(['content' => $content]);
+    $expected = Status::getMaxLength() - strlen($content);
+
+    expect($status->remaining_characters)->toBe($expected);
+});
+
+it('shows zero remaining characters when over limit', function () {
+    $longContent = str_repeat('a', Status::getMaxLength() + 10);
+    $status = Status::factory()->create(['content' => $longContent]);
+
+    expect($status->remaining_characters)->toBe(0);
+});
+
+it('can scope to public statuses', function () {
+    Status::factory()->create(['is_public' => true]);
+    Status::factory()->create(['is_public' => false]);
+
+    $publicStatuses = Status::public()->get();
+
+    expect($publicStatuses)->toHaveCount(1);
+    expect($publicStatuses->first()->is_public)->toBeTrue();
+});
+
+it('can scope to user statuses', function () {
+    $user1 = User::factory()->create();
+    $user2 = User::factory()->create();
+
+    Status::factory()->create(['user_id' => $user1->id]);
+    Status::factory()->create(['user_id' => $user2->id]);
+
+    $user1Statuses = Status::forUser($user1)->get();
+
+    expect($user1Statuses)->toHaveCount(1);
+    expect($user1Statuses->first()->user_id)->toBe($user1->id);
+});
+
+it('can scope to recent statuses', function () {
+    $oldStatus = Status::factory()->create(['created_at' => now()->subDays(5)]);
+    $newStatus = Status::factory()->create(['created_at' => now()]);
+
+    $recentStatuses = Status::recent(1)->get();
+
+    expect($recentStatuses)->toHaveCount(1);
+    expect($recentStatuses->first()->id)->toBe($newStatus->id);
+});
+
+it('can have comments', function () {
+    $status = Status::factory()->create();
+    $comment = \App\Models\Comment::factory()->create([
+        'commentable_type' => Status::class,
+        'commentable_id' => $status->id,
+    ]);
+
+    expect($status->comments)->toHaveCount(1);
+    expect($status->comments->first()->id)->toBe($comment->id);
+});
+
+it('only shows approved comments', function () {
+    $status = Status::factory()->create();
+    
+    \App\Models\Comment::factory()->create([
+        'commentable_type' => Status::class,
+        'commentable_id' => $status->id,
+        'is_approved' => true,
+    ]);
+    
+    \App\Models\Comment::factory()->create([
+        'commentable_type' => Status::class,
+        'commentable_id' => $status->id,
+        'is_approved' => false,
+    ]);
+
+    expect($status->comments)->toHaveCount(1);
+    expect($status->allComments)->toHaveCount(2);
+});
+
+it('uses soft deletes', function () {
+    $status = Status::factory()->create();
+    $statusId = $status->id;
+
+    $status->delete();
+
+    expect(Status::find($statusId))->toBeNull();
+    expect(Status::withTrashed()->find($statusId))->not->toBeNull();
+});


### PR DESCRIPTION
Add a configurable status update feature to user profiles, allowing reactions and with comments disabled for now.

---
<a href="https://cursor.com/background-agent?bcId=bc-989b70c0-044c-485c-8410-66074a45e78f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-989b70c0-044c-485c-8410-66074a45e78f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

